### PR TITLE
feat: enabling delivery status logging for lambda-dlq SNS topic

### DIFF
--- a/lambda-dlq/locals.tf
+++ b/lambda-dlq/locals.tf
@@ -1,2 +1,3 @@
 data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}

--- a/lambda-dlq/main.tf
+++ b/lambda-dlq/main.tf
@@ -1,6 +1,9 @@
 resource "aws_sns_topic" "lambda-dlq" {
-  name = "${var.name}-lambda-dlq"
-  kms_master_key_id = var.kms_master_key_id
+  name                             = "${var.name}-lambda-dlq"
+  kms_master_key_id                = var.kms_master_key_id
+  sqs_success_feedback_role_arn    = aws_iam_role.lambda-dlq-sns.arn
+  sqs_success_feedback_sample_rate = 100
+  sqs_failure_feedback_role_arn    = aws_iam_role.lambda-dlq-sns.arn
 }
 
 resource "aws_sns_topic_subscription" "lambda-dlq" {
@@ -10,7 +13,7 @@ resource "aws_sns_topic_subscription" "lambda-dlq" {
 }
 
 resource "aws_sqs_queue" "lambda-dlq" {
-  name = "${var.name}-lambda-dlq"
+  name                      = "${var.name}-lambda-dlq"
   message_retention_seconds = 1209600 # 14d
 
   kms_master_key_id = var.kms_master_key_id
@@ -18,14 +21,14 @@ resource "aws_sqs_queue" "lambda-dlq" {
 
 data "aws_iam_policy_document" "lambda-dlq" {
   statement {
-    sid = "DLQ"
-    effect = "Allow"
-    actions = ["sns:Publish"]
+    sid       = "DLQ"
+    effect    = "Allow"
+    actions   = ["sns:Publish"]
     resources = [aws_sns_topic.lambda-dlq.arn]
   }
   statement {
-    sid = "KMS"
-    effect = "Allow"
+    sid     = "KMS"
+    effect  = "Allow"
     actions = [
       "kms:GenerateDataKey",
       "kms:GenerateDataKeyPair",
@@ -33,10 +36,50 @@ data "aws_iam_policy_document" "lambda-dlq" {
       "kms:GenerateDataKeyWithoutPlaintext",
       "kms:Decrypt"
     ]
-    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:key/${var.kms_master_key_id}"]
+    resources = [
+      "arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:key/${var.kms_master_key_id}"
+    ]
   }
 }
 resource "aws_iam_policy" "lambda-dlq" {
-  name = "${var.name}-lambda-dlq-policy"
+  name   = "${var.name}-lambda-dlq-policy"
   policy = data.aws_iam_policy_document.lambda-dlq.json
+}
+
+data "aws_iam_policy_document" "lambda-dlq-sns" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["sns.${data.aws_partition.current.dns_suffix}"]
+    }
+  }
+}
+
+resource "aws_iam_role" "lambda-dlq-sns" {
+  name               = "${var.name}-lambda-dlq-sns-role"
+  path               = "/"
+  assume_role_policy = data.aws_iam_policy_document.lambda-dlq-sns.json
+}
+
+data "aws_iam_policy_document" "lambda-dlq-sns-delivery-status-role-policy" {
+  statement {
+    effect  = "Allow"
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:PutMetricFilter",
+      "logs:PutRetentionPolicy"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "lambda-dlq-sns-delivery-status-role-policy" {
+  name   = "${var.name}-lambda-dlq-sns-delivery-status-role-policy"
+  role   = aws_iam_role.lambda-dlq-sns.id
+  policy = data.aws_iam_policy_document.lambda-dlq-sns-delivery-status-role-policy.json
 }


### PR DESCRIPTION
See SNS.2 in [AWS Foundational Security Best Practices](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-sns-2)